### PR TITLE
Implement Content Length Guardrail

### DIFF
--- a/mediation/ai/content-length-guardrail/universal-gw/README.md
+++ b/mediation/ai/content-length-guardrail/universal-gw/README.md
@@ -1,0 +1,111 @@
+# Content Length Guardrail Mediator for WSO2 API Manager Universal Gateway
+
+The **Content Length Guardrail** is a custom Synapse mediator for **WSO2 API Manager Universal Gateway**, designed to perform **content-byte-length validation** on incoming or outgoing JSON payloads. This component acts as a *guardrail* to enforce specific content moderation rules based on configurable minimum and maximum byte sizes and JSONPath expressions.
+
+---
+
+## ✨ Features
+
+- ✅ Validate payload content by checking byte length
+- ✅ Define **minimum and maximum byte thresholds**
+- ✅ Target specific fields in JSON payloads using **JSONPath**
+- ✅ Optionally **invert validation logic** (e.g., allow only content *outside* the specified byte range)
+- ✅ Trigger fault sequences on rule violations
+- ✅ Include optional **assessment messages** in error responses for better observability
+
+---
+
+## 🛠️ Prerequisites
+
+- Java 11 (JDK)
+- Maven 3.6.x or later
+- WSO2 API Manager or Synapse-compatible runtime
+
+---
+
+## 📦 Building the Project
+
+To compile and package the mediator:
+
+```bash
+mvn clean install
+```
+
+> ℹ️ This will generate a `.zip` file in the `target/` directory containing the mediator JAR, policy-definition.json and artifact.j2.
+
+## 🚀 How to Use
+
+Follow these steps to integrate the Content Length Guardrail policy into your WSO2 API Manager instance:
+
+1. **Unzip the Build Artifact**  
+   After the build, unzip the artifact generated in the `target/` directory:
+
+   ```bash
+   unzip target/org.wso2.apim.policies.mediation.ai.content-length-guardrail-<version>-distribution.zip -d content-length-guardrail
+   ```
+
+2. **Copy the Mediator JAR**  
+   Place the mediator JAR into your API Manager’s runtime libraries:
+
+   ```bash
+   cp content-length-guardrail/org.wso2.apim.policies.mediation.ai.content-length-guardrail-<version>.jar $APIM_HOME/repository/components/lib/
+   ```
+
+3. **Register the Policy in Publisher**  
+   Use the provided `policy-definition.json` and `artifact.j2` files to define the policy in the Publisher Portal.
+
+   - Place these files in the correct directory structure expected by your deployment process or manually register via REST APIs or UIs.
+
+4. **Apply and Deploy the Policy**
+   - Open the **API Publisher**
+   - Select your API
+   - Go to **Runtime > Request/Response Flow**
+   - Click **Add Policy**, select the new **Content Length Guardrail** policy
+   - Provide the required configuration (name, min, max, etc.)
+   - **Save and Deploy** the API
+
+---
+
+## 🧾 Example Policy Configuration
+
+1. Create an AI API using Mistral AI.
+2. Add the Content Length Guardrail policy to the API with the following configuration:
+
+| Field                           | Example                  |
+|---------------------------------|--------------------------|
+| `Guardrail Name`                | `Content Limiter`        |
+| `Minimum Content Length`        | `20`                     |
+| `Maximum Content Length`        | `1500`                   |
+| `JSON Path`                     | `$.messages[-1].content` |
+| `Invert the Guardrail Decision` | `false`                  |
+| `Show Guardrail Assessment`     | `false`                  |
+
+3. Save and re-deploy the API.
+4. Invoke the API's `chat/completion` endpoint with a prompt that violates the byte count, such as a short string under the minimum threshold:
+
+```json
+{
+   "messages": [
+      {
+         "role": "user",
+         "content": "Hi!"
+      }
+   ]
+}
+```
+
+The following guardrail error response will be returned with http status code `446`:
+
+```json
+{
+   "code": "900514",
+   "type": "CONTENT_LENGTH_GUARDRAIL",
+   "message": {
+      "interveningGuardrail": "Content Limiter",
+      "action": "GUARDRAIL_INTERVENED",
+      "actionReason": "Violation of applied content length constraints detected.",
+      "direction": "REQUEST"
+   }
+}
+```
+---

--- a/mediation/ai/content-length-guardrail/universal-gw/content-length-guardrail/pom.xml
+++ b/mediation/ai/content-length-guardrail/universal-gw/content-length-guardrail/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.apim.policies</groupId>
+    <artifactId>org.wso2.apim.policies.mediation.ai.content-length-guardrail</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 APIM Mediation Policies - Content Length Guardrail</name>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <org.apache.felix.version>3.3.0</org.apache.felix.version>
+        <synapse.version>4.0.0-wso2v131</synapse.version>
+        <jackson.version>2.19.0</jackson.version>
+        <com.jayway.jsonpath.version>2.9.0.wso2v1</com.jayway.jsonpath.version>
+        <json.orbit.version>3.0.0.wso2v6</json.orbit.version>
+        <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
+        <axis2.osgi.version.range>[1.6.1, 1.7.0)</axis2.osgi.version.range>
+    </properties>
+
+    <dependencies>
+        <!-- Synapse Dependencies -->
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>${synapse.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Jackson for JSON Processing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- JSON Library -->
+        <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+            <version>${json.orbit.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.orbit.com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${com.jayway.jsonpath.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${org.apache.felix.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.wso2.apim.policies.mediation.ai.content.length.guardrail;version="${project.version}",
+                        </Export-Package>
+                        <Import-Package>
+                            !com.jayway.jsonpath.*,
+                            !net.minidev.json.*,
+                            !net.minidev.asm.*,
+                            !org.json.*,
+                            org.apache.axis2; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.description; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.engine; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.rpc.receivers; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.context; version="${axis2.osgi.version.range}",
+                            org.apache.commons.logging.*; version="${import.package.version.commons.logging}",
+                            org.apache.synapse,
+                            org.apache.synapse.config,
+                            org.apache.synapse.config.xml,
+                            org.apache.synapse.core,
+                            org.apache.synapse.core.axis2,
+                            org.apache.synapse.mediators.base,
+                            org.apache.axis2.transport.base,
+                            org.apache.synapse.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>
+                            json;scope=compile|runtime,
+                            json-path;scope=compile|runtime,
+                        </Embed-Dependency>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase> <!-- Runs after the JAR is built -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>zip.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+</project>

--- a/mediation/ai/content-length-guardrail/universal-gw/content-length-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/content/length/guardrail/ContentLengthGuardrail.java
+++ b/mediation/ai/content-length-guardrail/universal-gw/content-length-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/content/length/guardrail/ContentLengthGuardrail.java
@@ -1,0 +1,306 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.content.length.guardrail;
+
+import com.jayway.jsonpath.JsonPath;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.AbstractMediator;
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Content Length Guardrail mediator.
+ * <p>
+ * A Synapse mediator that validates the content length of incoming payloads. This guardrail ensures
+ * that the size of the request payload (in bytes) adheres to the defined minimum and maximum content
+ * length bounds. It helps enforce payload size restrictions, ensuring that the message size falls
+ * within the acceptable limits, enhancing system performance and security by preventing oversized payloads.
+ * <p>
+ * The validator supports JSONPath expressions to apply validation rules to specific sections of the payload.
+ * If no JSONPath is specified, the entire payload is validated against the content length constraints.
+ * The content length is calculated based on the UTF-8 byte size of the message.
+ * <p>
+ * If the validation fails, the mediator interrupts message processing, sets error details in the message context,
+ * and triggers a fault sequence. The response includes a structured assessment object with metadata about
+ * the content length violation, providing clear information about the size limits and the specific rule violation.
+ */
+public class ContentLengthGuardrail extends AbstractMediator implements ManagedLifecycle {
+    private static final Log logger = LogFactory.getLog(ContentLengthGuardrail.class);
+
+    private String name;
+    private int min;
+    private int max;
+    private String jsonPath = "";
+    private boolean invert = false;
+    private boolean showAssessment = true;
+
+    /**
+     * Initializes the ContentLengthGuardrail mediator.
+     *
+     * @param synapseEnvironment The Synapse environment instance.
+     */
+    @Override
+    public void init(SynapseEnvironment synapseEnvironment) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Initializing ContentLengthGuardrail.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("'min' cannot be greater than 'max'");
+        }
+    }
+
+    /**
+     * Destroys the ContentLengthGuardrail mediator instance and releases any allocated resources.
+     */
+    @Override
+    public void destroy() {
+        // No specific resources to release
+    }
+
+    /**
+     * The entry point for mediation. This method validates the content length of the incoming payload
+     * based on the configured bounds. If the content length is within the bounds, processing continues;
+     * otherwise, a fault sequence is triggered and further processing is stopped.
+     *
+     * @param messageContext The Synapse message context, which contains the request payload.
+     * @return {@code true} if validation is successful and processing should continue; {@code false}
+     *         if validation fails and further processing should be stopped.
+     */
+    @Override
+    public boolean mediate(MessageContext messageContext) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Beginning payload validation.");
+        }
+
+        try {
+            int count = getContentCount(messageContext);
+            boolean validationResult = isCountWithinBounds(count);
+            boolean finalResult = invert != validationResult;
+
+            if (!finalResult) {
+                // Set error properties in message context
+                messageContext.setProperty(SynapseConstants.ERROR_CODE,
+                        ContentLengthGuardrailConstants.GUARDRAIL_APIM_EXCEPTION_CODE);
+                messageContext.setProperty(ContentLengthGuardrailConstants.ERROR_TYPE,
+                        ContentLengthGuardrailConstants.CONTENT_LENGTH_GUARDRAIL);
+                messageContext.setProperty(ContentLengthGuardrailConstants.CUSTOM_HTTP_SC,
+                        ContentLengthGuardrailConstants.GUARDRAIL_ERROR_CODE);
+
+                // Build assessment details
+                String assessmentObject = buildAssessmentObject(count, messageContext.isResponse());
+                messageContext.setProperty(SynapseConstants.ERROR_MESSAGE, assessmentObject);
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Validation failed - triggering fault sequence.");
+                }
+
+                Mediator faultMediator = messageContext.getSequence(ContentLengthGuardrailConstants.FAULT_SEQUENCE_KEY);
+                if (faultMediator == null) {
+                    messageContext.setProperty(SynapseConstants.ERROR_MESSAGE,
+                            "Violation of " + name + " detected.");
+                    faultMediator = messageContext.getFaultSequence(); // Fall back to default error sequence
+                }
+
+                faultMediator.mediate(messageContext);
+                return false; // Stop further processing
+            }
+        } catch (Exception e) {
+            logger.error("Error during mediation", e);
+
+            messageContext.setProperty(SynapseConstants.ERROR_CODE,
+                    ContentLengthGuardrailConstants.APIM_INTERNAL_EXCEPTION_CODE);
+            messageContext.setProperty(SynapseConstants.ERROR_MESSAGE,
+                    "Error occurred during ContentLengthGuardrail mediation");
+            Mediator faultMediator = messageContext.getFaultSequence();
+            faultMediator.mediate(messageContext);
+            return false; // Stop further processing
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks whether the given character count is within the configured minimum and maximum bounds.
+     *
+     * @param count The number of words to evaluate.
+     * @return {@code true} if the word count is within bounds; {@code false} otherwise.
+     */
+    private boolean isCountWithinBounds(int count) {
+        return min <= count && max >= count;
+    }
+
+    /**
+     * Validates the payload by extracting JSON and calculating content length.
+     *
+     * @param messageContext the Synapse message context
+     * @return {@code true} if the byte length of the input is between {@code min} and {@code max} (inclusive),
+     * {@code false} otherwise.
+     */
+    private int getContentCount(MessageContext messageContext) {
+        String jsonContent = extractJsonContent(messageContext);
+        if (jsonContent == null || jsonContent.isEmpty()) {
+            return count("");
+        }
+
+        // If no JSON path is specified, apply validation to the entire JSON content
+        if (jsonPath == null || jsonPath.trim().isEmpty()) {
+            return count(jsonContent);
+        }
+
+        String content = JsonPath.read(jsonContent, jsonPath).toString();
+
+        // Remove quotes at beginning and end
+        String cleanedText = content.replaceAll(ContentLengthGuardrailConstants.TEXT_CLEAN_REGEX, "").trim();
+
+        return count(cleanedText);
+    }
+
+    /**
+     * Counts the number of bytes in a given text.
+     * <p>
+     * Words are separated by whitespace. Quotes at the beginning and end of the text are removed
+     * before counting.
+     *
+     * @param text The text to analyze.
+     * @return The number of bytes found.
+     */
+    private int count(String text) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Counting bytes in extracted text.");
+        }
+
+        return text.getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    /**
+     * Extracts JSON content from the message context.
+     * This utility method converts the Axis2 message payload to a JSON string.
+     *
+     * @param messageContext The message context containing the JSON payload
+     * @return The JSON payload as a string, or null if extraction fails
+     */
+    private String extractJsonContent(MessageContext messageContext) {
+        org.apache.axis2.context.MessageContext axis2MC =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        return JsonUtil.jsonPayloadToString(axis2MC);
+    }
+
+    /**
+     * Builds a JSON object containing assessment details for guardrail responses.
+     * This JSON includes information about why the guardrail intervened.
+     *
+     * @return A JSON string representing the assessment object
+     */
+    private String buildAssessmentObject(int count, boolean isResponse) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Building assessment");
+        }
+
+        JSONObject assessmentObject = new JSONObject();
+
+        assessmentObject.put(ContentLengthGuardrailConstants.ASSESSMENT_ACTION, "GUARDRAIL_INTERVENED");
+        assessmentObject.put(ContentLengthGuardrailConstants.INTERVENING_GUARDRAIL, name);
+        assessmentObject.put(ContentLengthGuardrailConstants.DIRECTION, isResponse? "RESPONSE" : "REQUEST");
+        assessmentObject.put(ContentLengthGuardrailConstants.ASSESSMENT_REASON,
+                "Violation of applied content length constraints detected.");
+
+        if (showAssessment) {
+            String message = String.format(
+                    "Expected %s %d %s %d bytes. But found %d.", invert? "less than" : "between", min,
+                    invert? "or more than": "and", max, count
+            );
+
+            assessmentObject.put(ContentLengthGuardrailConstants.ASSESSMENTS, message);
+        }
+
+        return assessmentObject.toString();
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public int getMin() {
+
+        return min;
+    }
+
+    public void setMin(int min) {
+
+        this.min = min;
+    }
+
+    public int getMax() {
+
+        return max;
+    }
+
+    public void setMax(int max) {
+
+        this.max = max;
+    }
+
+    public String getJsonPath() {
+
+        return jsonPath;
+    }
+
+    public void setJsonPath(String jsonPath) {
+
+        this.jsonPath = jsonPath;
+    }
+
+    public boolean isInvert() {
+
+        return invert;
+    }
+
+    public void setInvert(boolean invert) {
+
+        this.invert = invert;
+    }
+
+    public boolean isShowAssessment() {
+
+        return showAssessment;
+    }
+
+    public void setShowAssessment(boolean showAssessment) {
+
+        this.showAssessment = showAssessment;
+    }
+}

--- a/mediation/ai/content-length-guardrail/universal-gw/content-length-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/content/length/guardrail/ContentLengthGuardrailConstants.java
+++ b/mediation/ai/content-length-guardrail/universal-gw/content-length-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/content/length/guardrail/ContentLengthGuardrailConstants.java
@@ -1,0 +1,37 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.content.length.guardrail;
+
+public class ContentLengthGuardrailConstants {
+    public static final int GUARDRAIL_ERROR_CODE = 446;
+    public static final int GUARDRAIL_APIM_EXCEPTION_CODE = 900514;
+    public static final int APIM_INTERNAL_EXCEPTION_CODE = 900967;
+    public static final String ERROR_TYPE = "ERROR_TYPE";
+    public static final String CUSTOM_HTTP_SC = "CUSTOM_HTTP_SC";
+    public static final String FAULT_SEQUENCE_KEY = "guardrail_fault";
+    public static final String INTERVENING_GUARDRAIL = "interveningGuardrail";
+    public static final String DIRECTION = "direction";
+    public static final String ASSESSMENT_ACTION = "action";
+    public static final String ASSESSMENT_REASON = "actionReason";
+    public static final String ASSESSMENTS = "assessments";
+    public static final String CONTENT_LENGTH_GUARDRAIL = "CONTENT_LENGTH_GUARDRAIL";
+    public static final String TEXT_CLEAN_REGEX = "^\"|\"$";
+}

--- a/mediation/ai/content-length-guardrail/universal-gw/content-length-guardrail/zip.xml
+++ b/mediation/ai/content-length-guardrail/universal-gw/content-length-guardrail/zip.xml
@@ -1,0 +1,27 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <!-- Include the JAR -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+        <!-- Include the ../resources directory -->
+        <fileSet>
+            <directory>${basedir}/../resources</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/mediation/ai/content-length-guardrail/universal-gw/resources/artifact.j2
+++ b/mediation/ai/content-length-guardrail/universal-gw/resources/artifact.j2
@@ -1,0 +1,8 @@
+<class name="org.wso2.apim.policies.mediation.ai.content.length.guardrail.ContentLengthGuardrail">
+    <property action="set" name="name" value="{{name}}"/>
+    <property action="set" name="min" type="INTEGER" value="{{min}}"/>
+    <property action="set" name="max" type="INTEGER" value="{{max}}"/>
+    <property action="set" name="jsonPath" value="{{jsonPath}}"/>
+    <property action="set" name="invert" type="BOOLEAN" value="{{invert}}"/>
+    <property action="set" name="showAssessment" type="BOOLEAN" value="{{showAssessment}}"/>
+</class>

--- a/mediation/ai/content-length-guardrail/universal-gw/resources/policy-definition.json
+++ b/mediation/ai/content-length-guardrail/universal-gw/resources/policy-definition.json
@@ -1,0 +1,74 @@
+{
+  "category": "Mediation",
+  "name": "ContentLengthGuardrail",
+  "version": "v1.0",
+  "displayName": "Content Length Guardrail",
+  "description": "Validates the request or response content to ensure it complies with the specified minimum and maximum content length limits.",
+  "applicableFlows": [
+    "request",
+    "response"
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "supportedApiTypes": [
+    {
+      "subType": "AIAPI",
+      "apiType": "HTTP"
+    }
+  ],
+  "policyAttributes": [
+    {
+      "name": "name",
+      "displayName": "Guardrail Name",
+      "description": "The name of the guardrail policy. This will be used for tracking purposes.",
+      "type": "String",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "min",
+      "displayName": "Minimum Content Length",
+      "description": "The minimum number of bytes the content must contain.",
+      "type": "Integer",
+      "validationRegex": "^[1-9][0-9]*$",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "max",
+      "displayName": "Maximum Content Length",
+      "description": "The maximum number of bytes the content must contain.",
+      "type": "Integer",
+      "validationRegex": "^[1-9][0-9]*$",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "jsonPath",
+      "displayName": "JSON Path",
+      "description": "The JSONPath expression used to extract content from the payload. If not specified, the entire payload will be used for validation.",
+      "type": "String",
+      "allowedValues": [],
+      "required": false
+    },
+    {
+      "name": "invert",
+      "displayName": "Invert the Guardrail Decision",
+      "description": "If enabled, inverts the guardrail blocking decision, causing the guardrail to intervene and return an error response when a match is found in the content.",
+      "type": "Boolean",
+      "allowedValues": [],
+      "defaultValue": "false",
+      "required": false
+    },
+    {
+      "name": "showAssessment",
+      "displayName": "Show Guardrail Assessment",
+      "description": "When enabled, the error response will include detailed information about the reason for the guardrail intervention.",
+      "type": "Boolean",
+      "defaultValue": "false",
+      "allowedValues": [],
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
To implement a mediation policy that serves as a sentence count validation guardrail within the API Gateway.

## Approach
Develop a custom Synapse mediator that performs content length validation on specified parts of a JSON payload, identified using a JSONPath expression. This policy can be applied to both request and response flows and is configurable to allow or reject traffic based on whether the byte length of the extracted content falls within defined minimum and maximum limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Content Length Guardrail policy for API payload validation, allowing enforcement of minimum and maximum byte length constraints on JSON fields.
  - Supports configurable parameters including target JSONPath, inversion of logic, and detailed assessment in error responses.
  - Provides example configurations and integration steps for WSO2 API Manager Universal Gateway.

- **Documentation**
  - Added comprehensive README with setup, configuration, and usage instructions for the Content Length Guardrail policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->