### PR TITLE
Implement URL Guardrail

### DIFF
--- a/mediation/ai/url-guardrail/universal-gw/README.md
+++ b/mediation/ai/url-guardrail/universal-gw/README.md
@@ -1,0 +1,127 @@
+# URL Guardrail Mediator for WSO2 API Manager Universal Gateway
+
+The **URL Guardrail** is a custom Synapse mediator for **WSO2 API Manager Universal Gateway**, designed to perform **URL validity checks** on incoming or outgoing JSON payloads. This component acts as a *guardrail* to enforce content safety by validating embedded URLs for accessibility or DNS resolution.
+
+---
+
+## ✨ Features
+
+- ✅ Validate payload content by extracting and checking URLs
+- ✅ Perform either **DNS resolution** or **HTTP HEAD** validation
+- ✅ Target specific fields in JSON payloads using **JSONPath**
+- ✅ Configure custom **timeout** for validation checks
+- ✅ Trigger fault sequences on rule violations
+- ✅ Include optional **assessment messages** in error responses for better observability
+
+---
+
+## 🛠️ Prerequisites
+
+- Java 11 (JDK)
+- Maven 3.6.x or later
+- WSO2 API Manager or Synapse-compatible runtime
+
+---
+
+## 📦 Building the Project
+
+To compile and package the mediator:
+
+```bash
+mvn clean install
+```
+
+> ℹ️ This will generate a `.zip` file in the `target/` directory containing the mediator JAR, policy-definition.json, and artifact.j2.
+
+---
+
+## 🚀 How to Use
+
+Follow these steps to integrate the URL Guardrail policy into your WSO2 API Manager instance:
+
+1. **Unzip the Build Artifact**
+
+```bash
+unzip target/org.wso2.apim.policies.mediation.ai.url-guardrail-<version>-distribution.zip -d url-guardrail
+```
+
+2. **Copy the Mediator JAR**
+
+```bash
+cp url-guardrail/org.wso2.apim.policies.mediation.ai.url-guardrail-<version>.jar $APIM_HOME/repository/components/lib/
+```
+
+3. **Register the Policy in Publisher**
+
+- Use the `policy-definition.json` and `artifact.j2` files to define the policy in the Publisher Portal.
+- Place them appropriately in your custom policy deployment directory or register via the REST API.
+
+4. **Apply and Deploy the Policy**
+
+- Go to **API Publisher**
+- Select your API
+- Navigate to **Runtime > Request/Response Flow**
+- Click **Add Policy** and choose **URL Guardrail**
+- Configure the policy parameters (name, JSONPath, timeout, etc.)
+- **Save and Deploy** the API
+
+---
+
+## 🧾 Example Policy Configuration
+
+1. Create an AI API using Mistral AI.
+2. Add the URL Guardrail policy to the API with the following configuration:
+
+| Field                       | Example                  |
+|-----------------------------|--------------------------|
+| `Guardrail Name`            | `URL Safety Guard`       |
+| `JSON Path`                 | `$.messages[-1].content` |
+| `Connection Timeout`        | `3000`                   |
+| `Perform DNS Lookup`        | `false`                  |
+| `Show Guardrail Assessment` | `false`                  |
+
+3. Save and re-deploy the API.
+4. Invoke the API's `chat/completion` endpoint with a prompt that violates the URL validity rule.
+
+```json
+{
+  "model": "mistral-small-latest",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Please summerize content from http://test.fake"
+    }
+  ]
+}
+```
+
+The following guardrail error response will be returned with http status code `446`:
+
+```json
+{
+  "code": "900514",
+  "type": "URL_GUARDRAIL",
+  "message": {
+    "interveningGuardrail": "URL Safety Guard",
+    "action": "GUARDRAIL_INTERVENED",
+    "actionReason": "Violation of url validity detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+---
+
+## ⚠️ Limitations
+
+The **URL Guardrail** uses the following regular expression to extract URLs from the inspected content:
+
+```regex
+https?://[^\\s,"'{}\[\]\\`]+
+```
+
+This pattern is designed to match common URL formats in textual content. However, it may **overmatch** or extract **unintended portions** as URLs in certain edge cases.
+
+> 🔒 If such unintended content is matched as a URL and fails the validation (DNS/HTTP), the guardrail will **intervene** and block the mediation flow.
+
+---

--- a/mediation/ai/url-guardrail/universal-gw/resources/artifact.j2
+++ b/mediation/ai/url-guardrail/universal-gw/resources/artifact.j2
@@ -1,0 +1,7 @@
+<class name="org.wso2.apim.policies.mediation.ai.url.guardrail.URLGuardrail">
+    <property action="set" name="name" value="{{name}}"/>
+    <property action="set" name="jsonPath" value="{{jsonPath}}"/>
+    <property action="set" name="timeout" type="INTEGER" value="{{timeout}}"/>
+    <property action="set" name="onlyDNS" type="BOOLEAN" value="{{onlyDNS}}"/>
+    <property action="set" name="showAssessment" type="BOOLEAN" value="{{showAssessment}}"/>
+</class>

--- a/mediation/ai/url-guardrail/universal-gw/resources/policy-definition.json
+++ b/mediation/ai/url-guardrail/universal-gw/resources/policy-definition.json
@@ -1,0 +1,66 @@
+{
+  "category": "Mediation",
+  "name": "URLGuardrail",
+  "version": "v1.0",
+  "displayName": "URL Guardrail",
+  "description": "Extract and Validate URLs included in the request or response content by either performing a DNS lookup or a connection establishment.",
+  "applicableFlows": [
+    "request",
+    "response"
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "supportedApiTypes": [
+    {
+      "subType": "AIAPI",
+      "apiType": "HTTP"
+    }
+  ],
+  "policyAttributes": [
+    {
+      "name": "name",
+      "displayName": "Guardrail Name",
+      "description": "The name of the guardrail policy. This will be used for tracking purposes.",
+      "type": "String",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "jsonPath",
+      "displayName": "JSON Path",
+      "description": "The JSONPath expression used to extract content from the payload. If not specified, the entire payload will be used for validation.",
+      "type": "String",
+      "allowedValues": [],
+      "required": false
+    },
+    {
+      "name": "onlyDNS",
+      "displayName": "Perform DNS Lookup",
+      "description": "If enabled, a DNS lookup will be performed to validate the extracted URLs. If disabled, a connection attempt will be made instead.\n",
+      "type": "Boolean",
+      "allowedValues": [],
+      "defaultValue": "false",
+      "required": false
+    },
+    {
+      "name": "timeout",
+      "displayName": "Connection Timeout",
+      "description": "The connection timeout for DNS lookups or connection attempts, in milliseconds. If not specified, a default timeout will be used.",
+      "type": "Integer",
+      "defaultValue": "3000",
+      "validationRegex": "^[1-9][0-9]*$",
+      "allowedValues": [],
+      "required": false
+    },
+    {
+      "name": "showAssessment",
+      "displayName": "Show Guardrail Assessment",
+      "description": "When enabled, the error response will include detailed information about the reason for the guardrail intervention.",
+      "type": "Boolean",
+      "defaultValue": "false",
+      "allowedValues": [],
+      "required": false
+    }
+  ]
+}

--- a/mediation/ai/url-guardrail/universal-gw/url-guardrail/assembly-zip.xml
+++ b/mediation/ai/url-guardrail/universal-gw/url-guardrail/assembly-zip.xml
@@ -1,0 +1,27 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <!-- Include the JAR -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+        <!-- Include the ../resources directory -->
+        <fileSet>
+            <directory>${basedir}/../resources</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/mediation/ai/url-guardrail/universal-gw/url-guardrail/pom.xml
+++ b/mediation/ai/url-guardrail/universal-gw/url-guardrail/pom.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.apim.policies</groupId>
+    <artifactId>org.wso2.apim.policies.mediation.ai.url-guardrail</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 APIM Mediation Policies - URL Guardrail</name>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <org.apache.felix.version>3.3.0</org.apache.felix.version>
+        <synapse.version>4.0.0-wso2v131</synapse.version>
+        <jackson.version>2.19.0</jackson.version>
+        <com.jayway.jsonpath.version>2.9.0.wso2v1</com.jayway.jsonpath.version>
+        <json.orbit.version>3.0.0.wso2v6</json.orbit.version>
+        <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
+        <axis2.osgi.version.range>[1.6.1, 1.7.0)</axis2.osgi.version.range>
+    </properties>
+
+    <dependencies>
+        <!-- Synapse Dependencies -->
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>${synapse.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Jackson for JSON Processing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- JSON Library -->
+        <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+            <version>${json.orbit.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.orbit.com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${com.jayway.jsonpath.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${org.apache.felix.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.wso2.apim.policies.mediation.ai.url.guardrail;version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            !com.jayway.jsonpath.*,
+                            !net.minidev.json.*,
+                            !net.minidev.asm.*,
+                            !org.json.*,
+                            org.apache.axis2; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.description; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.engine; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.rpc.receivers; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.context; version="${axis2.osgi.version.range}",
+                            org.apache.commons.logging.*; version="${import.package.version.commons.logging}",
+                            org.apache.synapse,
+                            org.apache.synapse.config,
+                            org.apache.synapse.config.xml,
+                            org.apache.synapse.core,
+                            org.apache.synapse.core.axis2,
+                            org.apache.synapse.mediators.base,
+                            org.apache.axis2.transport.base,
+                            org.apache.synapse.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>
+                            json;scope=compile|runtime,
+                            json-path;scope=compile|runtime
+                        </Embed-Dependency>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase> <!-- Runs after the JAR is built -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly-zip.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+</project>

--- a/mediation/ai/url-guardrail/universal-gw/url-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/url/guardrail/URLGuardrail.java
+++ b/mediation/ai/url-guardrail/universal-gw/url-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/url/guardrail/URLGuardrail.java
@@ -1,0 +1,383 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.url.guardrail;
+
+import com.jayway.jsonpath.JsonPath;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.AbstractMediator;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * URL Guardrail mediator.
+ * <p>
+ * A Synapse mediator that performs URL validation on payloads by extracting URLs from JSON content
+ * and validating them either via DNS resolution or HTTP connectivity checks. This guardrail ensures
+ * that external references in payloads point to reachable or resolvable hosts, enhancing input safety
+ * and reducing the risk of external threats.
+ * <p>
+ * The validator supports JSONPath expressions to isolate specific sections of the payload for
+ * URL extraction. If no JSONPath is provided, the entire payload is scanned for URL patterns.
+ * Based on configuration, the guardrail performs lightweight DNS lookups or full HTTP HEAD requests.
+ * <p>
+ * If validation fails, the mediator halts message processing, sets error details in the message context,
+ * and invokes a configured fault sequence. The response includes a structured assessment object with
+ * metadata about the guardrail intervention.
+ */
+public class URLGuardrail extends AbstractMediator implements ManagedLifecycle {
+    private static final Log logger = LogFactory.getLog(URLGuardrail.class);
+
+    private String name;
+    private String jsonPath = "";
+    private int timeout = 3000; // 3s
+    private boolean onlyDNS = false;
+    private boolean showAssessment = true;
+
+    /**
+     * Initializes the URLGuardrail mediator.
+     *
+     * @param synapseEnvironment The Synapse environment instance.
+     */
+    @Override
+    public void init(SynapseEnvironment synapseEnvironment) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Initializing Guardrail");
+        }
+    }
+
+    /**
+     * Destroys the URLGuardrail mediator instance and releases any allocated resources.
+     */
+    @Override
+    public void destroy() {
+        // No specific resources to release
+    }
+
+    /**
+     * Entry point for mediation. Performs URL validation against the incoming JSON payload.
+     *
+     * @param messageContext the Synapse message context
+     * @return true if validation passed and processing should continue; false if blocked
+     */
+    @Override
+    public boolean mediate(MessageContext messageContext) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Starting mediation.");
+        }
+
+        try {
+            List<String> invalidUrls = validatePayload(messageContext);
+
+            if (!invalidUrls.isEmpty()) {
+                // Set error properties in message context
+                messageContext.setProperty(SynapseConstants.ERROR_CODE,
+                        URLGuardrailConstants.GUARDRAIL_APIM_EXCEPTION_CODE);
+                messageContext.setProperty(URLGuardrailConstants.ERROR_TYPE, URLGuardrailConstants.URL_GUARDRAIL);
+                messageContext.setProperty(URLGuardrailConstants.CUSTOM_HTTP_SC,
+                        URLGuardrailConstants.GUARDRAIL_ERROR_CODE);
+
+                // Build assessment details
+                String assessmentObject = buildAssessmentObject(invalidUrls, messageContext.isResponse());
+                messageContext.setProperty(SynapseConstants.ERROR_MESSAGE, assessmentObject);
+                logger.info("Validation failed - triggering fault sequence.");
+
+                Mediator faultMediator = messageContext.getSequence(URLGuardrailConstants.FAULT_SEQUENCE_KEY);
+                if (faultMediator == null) {
+                    messageContext.setProperty(SynapseConstants.ERROR_MESSAGE,
+                            "Violation of " + name + " detected.");
+                    faultMediator = messageContext.getFaultSequence(); // Fall back to default error sequence
+                }
+
+                faultMediator.mediate(messageContext);
+                return false; // Stop further processing
+            }
+        } catch (Exception e) {
+            logger.error("Error during mediation", e);
+
+            messageContext.setProperty(SynapseConstants.ERROR_CODE, URLGuardrailConstants.APIM_INTERNAL_EXCEPTION_CODE);
+            messageContext.setProperty(SynapseConstants.ERROR_MESSAGE, "Error occurred during URLGuardrail mediation");
+            Mediator faultMediator = messageContext.getFaultSequence();
+            faultMediator.mediate(messageContext);
+            return false; // Stop further processing
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates the payload by extracting JSON and scanning for URLs.
+     *
+     * @param messageContext the Synapse message context
+     * @return a list of invalid URLs; an empty list if all are valid
+     */
+    private List<String> validatePayload(MessageContext messageContext) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Validating payload.");
+        }
+
+        String jsonContent = extractJsonContent(messageContext);
+        if (jsonContent == null || jsonContent.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // If no JSON path is specified, apply validation to the entire JSON content
+        if (jsonPath == null || jsonPath.trim().isEmpty()) {
+            return validateJsonAgainstURL(jsonContent);
+        }
+
+        return validateJsonAgainstURL(JsonPath.read(jsonContent, jsonPath).toString());
+    }
+
+    /**
+     * Validates a given JSON string by extracting and checking all contained URLs.
+     *
+     * @param input the JSON or string content
+     * @return a list of invalid URLs; an empty list if all are valid
+     */
+    private List<String> validateJsonAgainstURL(String input) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Validating extracted URLs.");
+        }
+
+        Set<String> urls = extractUrls(input);
+        if (urls.isEmpty()) return Collections.emptyList();
+
+        Map<String, CompletableFuture<Boolean>> futureMap = urls.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        url -> CompletableFuture.supplyAsync(() -> {
+                            try {
+                                return onlyDNS ? checkDNS(url) : checkUrl(url);
+                            } catch (Exception e) {
+                                logger.error("Error validating URL: " + url, e);
+                                return false;
+                            }
+                        })
+                ));
+
+        // Wait for all tasks to complete
+        CompletableFuture.allOf(futureMap.values().toArray(new CompletableFuture[0])).join();
+
+        return futureMap.entrySet().stream()
+                .filter(entry -> !entry.getValue().join())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Extracts all URLs from the input string using a simple regex.
+     *
+     * @param input input string containing potential URLs
+     * @return set of extracted URLs
+     */
+    private Set<String> extractUrls(String input) {
+        Pattern urlPattern = Pattern.compile(URLGuardrailConstants.URL_REGEX);
+        Matcher matcher = urlPattern.matcher(input);
+
+        Set<String> urls = new LinkedHashSet<>();
+        while (matcher.find()) {
+            urls.add(matcher.group());
+        }
+        return urls;
+    }
+
+    /**
+     * Checks if the URL is reachable via HTTP HEAD request.
+     *
+     * @param target URL to check
+     * @return true if reachable, false otherwise
+     */
+    private boolean checkUrl(String target) {
+        HttpClient client = HttpClient.newBuilder()
+                .version(Version.HTTP_1_1) // Explicitly use HTTP/1.1
+                .connectTimeout(Duration.ofMillis(timeout))
+                .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(target))
+                .timeout(Duration.ofMillis(timeout))
+                .method("HEAD", HttpRequest.BodyPublishers.noBody()) // HEAD request
+                .header("User-Agent", "URLValidator/1.0")
+                .build();
+
+        try {
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            int statusCode = response.statusCode();
+            return statusCode >= 200 && statusCode < 400;
+        } catch (IOException | InterruptedException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if the URL resolves via DNS.
+     *
+     * @param target URL to check
+     * @return true if DNS resolution is successful, false otherwise
+     */
+    private boolean checkDNS(String target) {
+        try {
+            URL url = new URL(target);
+            String host = url.getHost();
+
+            String dnsUrl = "https://1.1.1.1/dns-query?name=" + host;
+            HttpURLConnection connection = (HttpURLConnection) new URL(dnsUrl).openConnection();
+            connection.setRequestProperty("Accept", "application/dns-json");
+            connection.setConnectTimeout(timeout);
+            connection.setReadTimeout(timeout);
+
+            InputStream inputStream = connection.getInputStream();
+            String responseBody = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            inputStream.close();
+
+            // Parse JSON to check DNS status and answer
+            JSONObject json = new JSONObject(responseBody);
+            int status = json.getInt("Status");
+            JSONArray answers = json.optJSONArray("Answer");
+
+            return status == 0 && answers != null && answers.length() > 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+
+    /**
+     * Extracts JSON content from the message context.
+     * This utility method converts the Axis2 message payload to a JSON string.
+     *
+     * @param messageContext The message context containing the JSON payload
+     * @return The JSON payload as a string, or null if extraction fails
+     */
+    private String extractJsonContent(MessageContext messageContext) {
+        org.apache.axis2.context.MessageContext axis2MC =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        return JsonUtil.jsonPayloadToString(axis2MC);
+    }
+
+    /**
+     * Builds a JSON object containing assessment details for guardrail responses.
+     * This JSON includes information about why the guardrail intervened.
+     *
+     * @return A JSON string representing the assessment object
+     */
+    private String buildAssessmentObject(List<String> invalidUrls, boolean isResponse) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Building guardrail assessment object.");
+        }
+
+        JSONObject assessmentObject = new JSONObject();
+
+        assessmentObject.put(URLGuardrailConstants.ASSESSMENT_ACTION, "GUARDRAIL_INTERVENED");
+        assessmentObject.put(URLGuardrailConstants.INTERVENING_GUARDRAIL, name);
+        assessmentObject.put(URLGuardrailConstants.DIRECTION, isResponse? "RESPONSE" : "REQUEST");
+        assessmentObject.put(URLGuardrailConstants.ASSESSMENT_REASON, "Violation of url validity detected.");
+
+        if (showAssessment) {
+            JSONObject assessmentDetails = new JSONObject();
+            assessmentDetails.put("message", "One or more URLs in the payload failed validation.");
+            assessmentDetails.put("invalidUrls", new JSONArray(invalidUrls));
+            assessmentObject.put(URLGuardrailConstants.ASSESSMENTS, assessmentDetails);
+        }
+
+        return assessmentObject.toString();
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getJsonPath() {
+
+        return jsonPath;
+    }
+
+    public void setJsonPath(String jsonPath) {
+
+        this.jsonPath = jsonPath;
+    }
+
+    public int getTimeout() {
+
+        return timeout;
+    }
+
+    public void setTimeout(int timeout) {
+
+        this.timeout = timeout;
+    }
+
+    public boolean isOnlyDNS() {
+
+        return onlyDNS;
+    }
+
+    public void setOnlyDNS(boolean onlyDNS) {
+
+        this.onlyDNS = onlyDNS;
+    }
+
+    public boolean isShowAssessment() {
+
+        return showAssessment;
+    }
+
+    public void setShowAssessment(boolean showAssessment) {
+
+        this.showAssessment = showAssessment;
+    }
+}

--- a/mediation/ai/url-guardrail/universal-gw/url-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/url/guardrail/URLGuardrailConstants.java
+++ b/mediation/ai/url-guardrail/universal-gw/url-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/url/guardrail/URLGuardrailConstants.java
@@ -1,0 +1,37 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.url.guardrail;
+
+public class URLGuardrailConstants {
+    public static final int GUARDRAIL_ERROR_CODE = 446;
+    public static final int GUARDRAIL_APIM_EXCEPTION_CODE = 900514;
+    public static final int APIM_INTERNAL_EXCEPTION_CODE = 900967;
+    public static final String ERROR_TYPE = "ERROR_TYPE";
+    public static final String CUSTOM_HTTP_SC = "CUSTOM_HTTP_SC";
+    public static final String FAULT_SEQUENCE_KEY = "guardrail_fault";
+    public static final String ASSESSMENT_ACTION = "action";
+    public static final String ASSESSMENT_REASON = "actionReason";
+    public static final String ASSESSMENTS = "assessments";
+    public static final String INTERVENING_GUARDRAIL = "interveningGuardrail";
+    public static final String DIRECTION = "direction";
+    public static final String URL_GUARDRAIL = "URL_GUARDRAIL";
+    public static final String URL_REGEX = "https?://[^\\s,\"'{}\\[\\]\\\\`]+";
+}


### PR DESCRIPTION
## Purpose
To implement a mediation policy that serves as a url validation guardrail within the API Gateway.

## Approach
Develop a custom Synapse mediator that performs URL validation on specific parts of a JSON payload, identified using a JSONPath expression. This policy can be applied to both request and response flows and rejects traffic based on whether the extracted URLs are valid and resolvable via DNS or reachable via HTTP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a URL Guardrail policy for WSO2 API Manager Universal Gateway to validate URLs in JSON payloads, supporting both DNS and HTTP HEAD checks.
  - Added configurable settings for JSONPath extraction, timeout, DNS-only mode, and detailed assessment display.
  - Provides detailed error responses with invalid URL assessments when validation fails.

- **Documentation**
  - Added comprehensive README with setup, configuration, and usage instructions, including example policy configurations and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->